### PR TITLE
simple logger

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,6 @@ ColumnLimit: 80
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterFunction: true
-  AfterClass: true
   SplitEmptyRecord: false
 AlwaysBreakAfterReturnType: TopLevelDefinitions
 AlignAfterOpenBracket: DontAlign

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,10 @@ android {
 
 
         externalNativeBuild {
-            def ccFlags = ['-Werror', '-Wall', '-Winvalid-pch', '-Wextra', '-Wpedantic']
+            def ccFlags = [
+                '-Werror', '-Wall', '-Winvalid-pch', '-Wextra', '-Wpedantic',
+                '-Wno-gnu-zero-variadic-macro-arguments'
+            ]
 
             ndk {
                 abiFilters 'arm64-v8a'

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -19,15 +19,30 @@ add_library(
 # suppress warning
 target_compile_options(android_native_app_glue_object PRIVATE -w)
 
-set(Boost_DIR ${PROJECT_DIR}/build/boost)
-set(Boost_INCLUDE_DIR ${PROJECT_DIR}/build/boost/include)
-find_package(Boost REQUIRED)
+# Setup Boost
+set(Boost_VERSION 1.80.0)
+set(Boost_CMAKE_DIR "${PROJECT_DIR}/build/boost/lib/cmake")
+
+## Search for all available component-configuration directories
+file(GLOB all_components LIST_DIRECTORIES true 
+    RELATIVE "${Boost_CMAKE_DIR}" "${Boost_CMAKE_DIR}/boost_*-${Boost_VERSION}")
+## ...and extract components names from it.
+string(REGEX REPLACE "boost_([_a-z0-9]+)-${Boost_VERSION}" "\\1"
+    all_components "${all_components}")
+
+set(Boost_DIR "${Boost_CMAKE_DIR}/Boost-${Boost_VERSION}")
+foreach(component IN LISTS all_components)
+    set(boost_${component}_DIR "${Boost_CMAKE_DIR}/boost_${component}-${Boost_VERSION}")
+endforeach()
+
+find_package(Boost CONFIG REQUIRED)
 
 # main target
 add_library(
     zen_oculus_display_system MODULE
     
-    main.cpp
+    main.cc
+    logger-android.cc
     $<TARGET_OBJECTS:android_native_app_glue_object>
 )
 target_precompile_headers(zen_oculus_display_system PRIVATE pch.h)

--- a/app/src/main/cpp/logger-android.cc
+++ b/app/src/main/cpp/logger-android.cc
@@ -1,0 +1,54 @@
+#include "pch.h"
+
+#include "logger.h"
+
+namespace zen::display_system::oculus {
+
+namespace {
+
+class AndroidLogger : public ILogger {
+  virtual void Print(Severity severity,
+      [[maybe_unused]] const char* pretty_function,
+      [[maybe_unused]] const char* file, [[maybe_unused]] int line,
+      const char* format, ...) final
+  {
+    const char tag[] = "ZEN";
+    android_LogPriority priority = ANDROID_LOG_INFO;
+    switch (severity) {
+      case ILogger::DEBUG:
+        priority = ANDROID_LOG_DEBUG;
+        break;
+      case ILogger::INFO:
+        priority = ANDROID_LOG_INFO;
+        break;
+      case ILogger::WARN:
+        priority = ANDROID_LOG_WARN;
+        break;
+      case ILogger::ERROR:
+        priority = ANDROID_LOG_ERROR;
+        break;
+      case ILogger::FATAL:
+        priority = ANDROID_LOG_FATAL;
+        break;
+      default:
+        break;
+    }
+
+    va_list args;
+    va_start(args, format);
+    __android_log_vprint(priority, tag, format, args);
+    va_end(args);
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<ILogger> ILogger::instance;
+
+void
+InitializeLogger()
+{
+  ILogger::instance = std::make_unique<AndroidLogger>();
+}
+
+}  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/logger.h
+++ b/app/src/main/cpp/logger.h
@@ -1,0 +1,47 @@
+#pragma once
+
+namespace zen::display_system::oculus {
+
+struct ILogger {
+  // logger singleton set by InitializeLogger;
+  static std::unique_ptr<ILogger> instance;
+
+  typedef enum Severity {
+    DEBUG = 0,  // logs for debugging during development.
+    INFO,       // logs that may be useful to some users.
+    WARN,       // logs for recoverable failures.
+    ERROR,      // logs for unrecoverable failures.
+    FATAL,      // logs when aborting.
+    SILENT,     // for internal use only.
+  } Severity;
+
+  virtual ~ILogger() = default;
+
+  virtual void Print(Severity severity, const char* pretty_function,
+      const char* file, int line, const char* format, ...)
+      __attribute__((__format__(printf, 6, 7))) = 0;
+};
+
+#define LOG_DEBUG(format, ...)                                            \
+  ILogger::instance->Print(ILogger::DEBUG, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_INFO(format, ...)                                            \
+  ILogger::instance->Print(ILogger::INFO, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_WARN(format, ...)                                            \
+  ILogger::instance->Print(ILogger::WARN, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_ERROR(format, ...)                                            \
+  ILogger::instance->Print(ILogger::ERROR, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+#define LOG_FATAL(format, ...)                                            \
+  ILogger::instance->Print(ILogger::FATAL, __PRETTY_FUNCTION__, __FILE__, \
+      __LINE__, format, ##__VA_ARGS__)
+
+void InitializeLogger();
+
+}  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/main.cc
+++ b/app/src/main/cpp/main.cc
@@ -1,0 +1,13 @@
+#include "pch.h"
+
+#include "logger.h"
+
+using namespace zen::display_system::oculus;
+
+void
+android_main(struct android_app *app)
+{
+  InitializeLogger();
+  LOG_DEBUG("Boost Version %d", BOOST_VERSION);
+  (void)app;
+}

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -1,9 +1,0 @@
-#include "pch.h"
-
-void
-android_main(struct android_app *app)
-{
-  __android_log_print(
-      ANDROID_LOG_INFO, "ZEN", "Boost version %d", BOOST_VERSION);
-  (void)app;
-}

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -3,3 +3,4 @@
 #include <android/log.h>
 #include <android_native_app_glue.h>
 #include <boost/version.hpp>
+#include <memory>


### PR DESCRIPTION
## Context

We need a logger.

Several part of this repository may be used in zen compositor as a display system backend.
Boost's logger is too much and we need to be compile it. It's better to create a very simple logger, and it's enough.

## Summary

- [x] create very simple logger

## How to check behavior

Check the log output