### PR TITLE
Get XrSystem

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,4 +12,6 @@ IncludeCategories:
     Priority: 0
   - Regex: '.*'
     Priority: 1
-IfMacros: ['IF_XR_FAILED']
+IfMacros: 
+  - IF_XR_FAILED
+  - IF_EGL_FAILED

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -68,6 +68,7 @@ find_package(Boost CONFIG REQUIRED)
 add_library(
     zen_oculus_display_system MODULE
     
+    egl-instance.cc
     logger-android.cc
     main.cc
     openxr-program.cc

--- a/app/src/main/cpp/common.h
+++ b/app/src/main/cpp/common.h
@@ -5,3 +5,31 @@
   Class(Class &&) = delete;                 \
   Class &operator=(const Class &) = delete; \
   Class &operator=(Class &&) = delete
+
+#define TO_STRING(x) #x
+#define MACRO_TO_STRING(x) TO_STRING(x)
+#define FILE_AND_LINE __FILE__ ":" MACRO_TO_STRING(__LINE__)
+
+[[noreturn]] inline void
+Throw(std::string failure_message, const char *originator = nullptr,
+    const char *source_location = nullptr)
+{
+  std::ostringstream err;
+  err << failure_message;
+  if (originator != nullptr) {
+    err << std::endl << "    Origin: " << originator;
+  }
+
+  if (source_location != nullptr) {
+    err << std::endl << "    Source: " << source_location;
+  }
+
+  throw std::logic_error(err.str());
+}
+
+#define CHECK(exp)                                \
+  {                                               \
+    if (!(exp)) {                                 \
+      Throw("Check failed", #exp, FILE_AND_LINE); \
+    }                                             \
+  }

--- a/app/src/main/cpp/egl-instance.cc
+++ b/app/src/main/cpp/egl-instance.cc
@@ -91,7 +91,7 @@ EglInstance::Initialize()
     }
 
     // clang-format off
-    const EGLint config_attribs[] = {
+    constexpr EGLint config_attribs[] = {
         EGL_RED_SIZE,       8,
         EGL_GREEN_SIZE,     8,
         EGL_BLUE_SIZE,      8,
@@ -106,13 +106,12 @@ EglInstance::Initialize()
     for (int i = 0; i < num_configs; i++) {
       EGLint value = 0;
       eglGetConfigAttrib(display_, configs[i], EGL_RENDERABLE_TYPE, &value);
-      if ((value & EGL_OPENGL_ES3_BIT) != EGL_OPENGL_ES3_BIT) {
+      if (!(value & EGL_OPENGL_ES3_BIT)) {
         continue;
       }
 
       eglGetConfigAttrib(display_, configs[i], EGL_SURFACE_TYPE, &value);
-      if ((value & (EGL_WINDOW_BIT | EGL_PBUFFER_BIT)) !=
-          (EGL_WINDOW_BIT | EGL_PBUFFER_BIT)) {
+      if (!(value & EGL_WINDOW_BIT) || !(value & EGL_PBUFFER_BIT)) {
         continue;
       }
 
@@ -136,7 +135,7 @@ EglInstance::Initialize()
   }
 
   // clang-format off
-  EGLint context_attribs[] = {
+  constexpr EGLint context_attribs[] = {
       EGL_CONTEXT_CLIENT_VERSION, 3,
       EGL_NONE,
   };
@@ -150,7 +149,7 @@ EglInstance::Initialize()
   }
 
   // clang-format off
-  const EGLint surface_attribs[] = {
+  constexpr EGLint surface_attribs[] = {
       EGL_WIDTH,  16,
       EGL_HEIGHT, 16,
       EGL_NONE,

--- a/app/src/main/cpp/egl-instance.cc
+++ b/app/src/main/cpp/egl-instance.cc
@@ -1,0 +1,175 @@
+#include "pch.h"
+
+#include "egl-instance.h"
+#include "logger.h"
+
+namespace zen::display_system::oculus {
+
+namespace {
+
+static const char *
+EglErrorString(const EGLint error)
+{
+  switch (error) {
+    case EGL_SUCCESS:
+      return "EGL_SUCCESS";
+    case EGL_NOT_INITIALIZED:
+      return "EGL_NOT_INITIALIZED";
+    case EGL_BAD_ACCESS:
+      return "EGL_BAD_ACCESS";
+    case EGL_BAD_ALLOC:
+      return "EGL_BAD_ALLOC";
+    case EGL_BAD_ATTRIBUTE:
+      return "EGL_BAD_ATTRIBUTE";
+    case EGL_BAD_CONTEXT:
+      return "EGL_BAD_CONTEXT";
+    case EGL_BAD_CONFIG:
+      return "EGL_BAD_CONFIG";
+    case EGL_BAD_CURRENT_SURFACE:
+      return "EGL_BAD_CURRENT_SURFACE";
+    case EGL_BAD_DISPLAY:
+      return "EGL_BAD_DISPLAY";
+    case EGL_BAD_SURFACE:
+      return "EGL_BAD_SURFACE";
+    case EGL_BAD_MATCH:
+      return "EGL_BAD_MATCH";
+    case EGL_BAD_PARAMETER:
+      return "EGL_BAD_PARAMETER";
+    case EGL_BAD_NATIVE_PIXMAP:
+      return "EGL_BAD_NATIVE_PIXMAP";
+    case EGL_BAD_NATIVE_WINDOW:
+      return "EGL_BAD_NATIVE_WINDOW";
+    case EGL_CONTEXT_LOST:
+      return "EGL_CONTEXT_LOST";
+    default:
+      return "unknown";
+  }
+}
+
+std::string
+CheckEglResult(
+    EGLBoolean res, const char *originator, const char *source_location)
+{
+  std::ostringstream err;
+  if (res == EGL_FALSE) {
+    err << "EGL command failure: " << EglErrorString(eglGetError())
+        << std::endl;
+    err << "    Origin: " << originator << std::endl;
+    err << "    Source: " << source_location;
+  }
+
+  return err.str();
+}
+
+#define IF_EGL_FAILED(err, cmd) \
+  if (std::string err = CheckEglResult(cmd, #cmd, FILE_AND_LINE); !err.empty())
+
+}  // namespace
+
+bool
+EglInstance::Initialize()
+{
+  display_ = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  EGLint major_version, minor_version;
+
+  IF_EGL_FAILED (err, eglInitialize(display_, &major_version, &minor_version)) {
+    LOG_ERROR("%s", err.c_str());
+    return false;
+  }
+
+  LOG_INFO("EGL Version: %d.%d", major_version, minor_version);
+
+  // Find a config that satisfies `config_attribs` and several other conditions
+  {
+    constexpr int MAX_CONFIGS = 1024;
+    EGLConfig configs[MAX_CONFIGS];
+    EGLint num_configs = 0;
+    IF_EGL_FAILED (err,
+        eglGetConfigs(display_, configs, MAX_CONFIGS, &num_configs)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    // clang-format off
+    const EGLint config_attribs[] = {
+        EGL_RED_SIZE,       8,
+        EGL_GREEN_SIZE,     8,
+        EGL_BLUE_SIZE,      8,
+        EGL_ALPHA_SIZE,     8,
+        EGL_DEPTH_SIZE,     24,
+        EGL_SAMPLE_BUFFERS, 0,
+        EGL_SAMPLES,        0,
+        EGL_NONE,
+    };
+    // clang-format on
+
+    for (int i = 0; i < num_configs; i++) {
+      EGLint value = 0;
+      eglGetConfigAttrib(display_, configs[i], EGL_RENDERABLE_TYPE, &value);
+      if ((value & EGL_OPENGL_ES3_BIT) != EGL_OPENGL_ES3_BIT) {
+        continue;
+      }
+
+      eglGetConfigAttrib(display_, configs[i], EGL_SURFACE_TYPE, &value);
+      if ((value & (EGL_WINDOW_BIT | EGL_PBUFFER_BIT)) !=
+          (EGL_WINDOW_BIT | EGL_PBUFFER_BIT)) {
+        continue;
+      }
+
+      int j = 0;
+      for (; config_attribs[j] != EGL_NONE; j += 2) {
+        eglGetConfigAttrib(display_, configs[i], config_attribs[j], &value);
+        if (value != config_attribs[j + 1]) {
+          break;
+        }
+      }
+
+      if (config_attribs[j] == EGL_NONE) {
+        config_ = configs[i];
+      }
+    }
+  }
+
+  if (config_ == nullptr) {
+    LOG_ERROR("Failed to find a desired EGLConfig");
+    return false;
+  }
+
+  // clang-format off
+  EGLint context_attribs[] = {
+      EGL_CONTEXT_CLIENT_VERSION, 3,
+      EGL_NONE,
+  };
+  // clang-format on
+
+  context_ =
+      eglCreateContext(display_, config_, EGL_NO_CONTEXT, context_attribs);
+  if (context_ == EGL_NO_CONTEXT) {
+    LOG_ERROR("eglCreateContext() failed: %s", EglErrorString(eglGetError()));
+    return false;
+  }
+
+  // clang-format off
+  const EGLint surface_attribs[] = {
+      EGL_WIDTH,  16,
+      EGL_HEIGHT, 16,
+      EGL_NONE,
+  };
+  // clang-format on
+
+  surface_ = eglCreatePbufferSurface(display_, config_, surface_attribs);
+  if (surface_ == EGL_NO_SURFACE) {
+    LOG_ERROR(
+        "eglCreatePbufferSurface() failed %s", EglErrorString(eglGetError()));
+    return false;
+  }
+
+  IF_EGL_FAILED (err, eglMakeCurrent(display_, surface_, surface_, context_)) {
+    LOG_ERROR("%s", err.c_str());
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/egl-instance.h
+++ b/app/src/main/cpp/egl-instance.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "common.h"
+
+namespace zen::display_system::oculus {
+
+class EglInstance {
+ public:
+  DISABLE_MOVE_AND_COPY(EglInstance);
+  EglInstance() = default;
+  ~EglInstance() = default;
+
+  bool Initialize();
+
+ private:
+  EGLDisplay display_;
+  EGLConfig config_;
+  EGLContext context_;
+  EGLSurface surface_;
+};
+
+}  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/main.cc
+++ b/app/src/main/cpp/main.cc
@@ -29,6 +29,8 @@ android_main(struct android_app *app)
       return;
     }
 
+    // TODO: Register Debug Message Callback for OpenGL
+
     app->activity->vm->DetachCurrentThread();
   } catch (const std::exception &e) {
     LOG_ERROR("%s", e.what());

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "egl-instance.h"
+
 namespace zen::display_system::oculus {
 
 struct OpenXRContext {
@@ -7,6 +9,8 @@ struct OpenXRContext {
   XrSystemId system_id{XR_NULL_SYSTEM_ID};
   XrViewConfigurationType view_configuration_type{};
   XrEnvironmentBlendMode environment_blend_mode{};
+
+  std::unique_ptr<EglInstance> egl;
 
   static const XrViewConfigurationType kAcceptableViewConfigType =
       XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -1,6 +1,17 @@
 #pragma once
 
+namespace zen::display_system::oculus {
+
 struct OpenXRContext {
   XrInstance instance{XR_NULL_HANDLE};
   XrSystemId system_id{XR_NULL_SYSTEM_ID};
+  XrViewConfigurationType view_configuration_type{};
+  XrEnvironmentBlendMode environment_blend_mode{};
+
+  static const XrViewConfigurationType kAcceptableViewConfigType =
+      XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+  static const XrEnvironmentBlendMode kAcceptableEnvironmentBlendModeType =
+      XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
 };
+
+}  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -2,4 +2,5 @@
 
 struct OpenXRContext {
   XrInstance instance{XR_NULL_HANDLE};
+  XrSystemId system_id{XR_NULL_SYSTEM_ID};
 };

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -12,9 +12,9 @@ struct OpenXRContext {
 
   std::unique_ptr<EglInstance> egl;
 
-  static const XrViewConfigurationType kAcceptableViewConfigType =
+  static constexpr XrViewConfigurationType kAcceptableViewConfigType =
       XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
-  static const XrEnvironmentBlendMode kAcceptableEnvironmentBlendModeType =
+  static constexpr XrEnvironmentBlendMode kAcceptableEnvironmentBlendModeType =
       XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
 };
 

--- a/app/src/main/cpp/openxr-program.cc
+++ b/app/src/main/cpp/openxr-program.cc
@@ -126,7 +126,7 @@ OpenXRProgram::InitializeSystem(
     const std::unique_ptr<OpenXRContext> &context) const
 {
   CHECK(context->system_id == XR_NULL_SYSTEM_ID);
-  const XrFormFactor kFormFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
+  constexpr XrFormFactor kFormFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;
 
   XrSystemGetInfo system_info{XR_TYPE_SYSTEM_GET_INFO};
   system_info.formFactor = kFormFactor;

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -26,6 +26,10 @@ class OpenXRProgram {
   /* Get a XrSystem and store it in the context */
   bool InitializeSystem(const std::unique_ptr<OpenXRContext> &context) const;
 
+  /* Initialize EGL context and check OpenGL ES version */
+  bool InitializeGraphicsLibrary(
+      const std::unique_ptr<OpenXRContext> &context) const;
+
   /* Write out available view configurations, determine the view config type
    * to use and store it in the context */
   bool InitializeViewConfig(

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -23,6 +23,9 @@ class OpenXRProgram {
   bool InitializeInstance(const std::unique_ptr<OpenXRContext> &context,
       struct android_app *app) const;
 
+  /* Get a XrSystem and store it in the context */
+  bool InitializeSystem(const std::unique_ptr<OpenXRContext> &context) const;
+
   /* Write out XrInstance info */
   void LogInstanceInfo(const std::unique_ptr<OpenXRContext> &context) const;
 

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -26,6 +26,16 @@ class OpenXRProgram {
   /* Get a XrSystem and store it in the context */
   bool InitializeSystem(const std::unique_ptr<OpenXRContext> &context) const;
 
+  /* Write out available view configurations, determine the view config type
+   * to use and store it in the context */
+  bool InitializeViewConfig(
+      const std::unique_ptr<OpenXRContext> &context) const;
+
+  /* Write out available environment blend modes, determine the blend mode to
+   * use and store it in the context */
+  bool InitializeEnvironmentBlendMode(
+      const std::unique_ptr<OpenXRContext> &context) const;
+
   /* Write out XrInstance info */
   void LogInstanceInfo(const std::unique_ptr<OpenXRContext> &context) const;
 

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <EGL/egl.h>
+#include <GLES3/gl3.h>
+#include <GLES3/gl32.h>
 #include <android/log.h>
 #include <android_native_app_glue.h>
 #include <boost/version.hpp>

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -4,6 +4,7 @@
 #include <android/log.h>
 #include <android_native_app_glue.h>
 #include <boost/version.hpp>
+#include <cinttypes>
 #include <memory>
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>


### PR DESCRIPTION
# ce12e40

## Context

XrSystem
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#system
> This API separates the concept of physical systems of XR devices from the logical objects that applications interact with directly. A system represents a collection of related devices in the runtime, often made up of several individual hardware components working together to enable XR experiences. An [XrSystemId](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XrSystemId) is returned by [xrGetSystem](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#xrGetSystem) representing the system of devices the runtime will use to support a given [form factor](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#form_factor_description). Each system may include: a VR/AR display, various forms of input (gamepad, touchpad, motion controller), and other trackable objects.

## Summary

- [x] Get XrSystem for formFactor `XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY`

## How to check behavior

- build and run with your Oculus Quest
you will see the following log
```log
D/ZEN: Using system <id> for form factor XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY
```

# ac7f08e

## Context

View Configuration
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#view_configurations
> A view configuration is a semantically meaningful set of one or more views for which an application can render images.

Environment Blend Mode
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#environment_blend_mode
> After the compositor has blended and flattened all layers (including any layers added by the runtime itself), it will then present this image to the system’s display. The composited image will then blend with the user’s view of the physical world behind the displays in one of three modes, based on the application’s chosen environment blend mode. VR applications will generally choose the XR_ENVIRONMENT_BLEND_MODE_OPAQUE blend mode, while AR applications will generally choose either the XR_ENVIRONMENT_BLEND_MODE_ADDITIVE or XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND mode.

## Summary

- [x] Write out available view configurations and check that there is `XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO` type of configuration. (Oculus Quest should use it and we will not handle other types of view configurations).
- [x] Write out available environment blend mode and check that there is `XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO` type of blend mode. (Oculus Quest should use it and we will not handle other types of view configurations.)

## How to check behavior

- build and run with your Oculus Quest
you will see the following log
```log
D/ZEN: Available View Configuration Types: (1)
D/ZEN:   View Configuration Type: XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO (selected)
D/ZEN:   View Configuration FovMutable: True
D/ZEN:     View [0]: Recommended Width=1440 Height=1584 SampleCount=1
D/ZEN:     View [0]: Maximum Width=8192 Height=8192 SampleCount=1
D/ZEN:     View [1]: Recommended Width=1440 Height=1584 SampleCount=1
D/ZEN:     View [1]: Maximum Width=8192 Height=8192 SampleCount=1
D/ZEN: Available Environment Blend Modes for XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO: (1)
D/ZEN:     Mode [0]: XR_ENVIRONMENT_BLEND_MODE_OPAQUE (selected)
```

# d7a3316


## Context

We need to create a OpenGL context using EGL.

## Summary

- [x] Create EGL context
- [x] Check OpenGL version 

## How to check behavior

- build and run with your Oculus Quest
you will see the following log (versions can be different)
```log
I/ZEN: EGL Version: 1.5
I/ZEN: Using OpenGLES 3.2
```