### PR TITLE
create session

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "3rdParty/OpenXR-SDK"]
 	path = 3rdParty/OpenXR-SDK
 	url = https://github.com/KhronosGroup/OpenXR-SDK.git
+[submodule "3rdParty/glm"]
+	path = 3rdParty/glm
+	url = https://github.com/g-truc/glm.git

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -6,6 +6,8 @@ message(STATUS "Using CMake version: ${CMAKE_VERSION}")
 add_definitions(-DXR_USE_PLATFORM_ANDROID)
 add_definitions(-DXR_USE_GRAPHICS_API_OPENGL_ES)
 
+add_subdirectory(${ROOT_PROJECT_DIR}/3rdParty/glm binary_dir)
+
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/config.h.in 
     ${CMAKE_CURRENT_BINARY_DIR}/include/config.h
@@ -80,6 +82,7 @@ target_link_libraries(
     zen_oculus_display_system
 
     openxr_loader
+    glm
     ${android_library}
     ${android_log_library}
     ${egl_library}

--- a/app/src/main/cpp/egl-instance.h
+++ b/app/src/main/cpp/egl-instance.h
@@ -13,6 +13,7 @@ class EglInstance {
   bool Initialize();
 
   inline EGLDisplay display();
+  inline EGLConfig config();
   inline EGLDisplay context();
 
  private:
@@ -26,6 +27,12 @@ inline EGLDisplay
 EglInstance::display()
 {
   return display_;
+}
+
+inline EGLConfig
+EglInstance::config()
+{
+  return config_;
 }
 
 inline EGLContext

--- a/app/src/main/cpp/egl-instance.h
+++ b/app/src/main/cpp/egl-instance.h
@@ -12,11 +12,26 @@ class EglInstance {
 
   bool Initialize();
 
+  inline EGLDisplay display();
+  inline EGLDisplay context();
+
  private:
   EGLDisplay display_;
   EGLConfig config_;
   EGLContext context_;
   EGLSurface surface_;
 };
+
+inline EGLDisplay
+EglInstance::display()
+{
+  return display_;
+}
+
+inline EGLContext
+EglInstance::context()
+{
+  return context_;
+}
 
 }  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/main.cc
+++ b/app/src/main/cpp/main.cc
@@ -29,6 +29,7 @@ android_main(struct android_app *app)
       return;
     }
 
+    // TODO: Initialize actions
     // TODO: Register Debug Message Callback for OpenGL
 
     app->activity->vm->DetachCurrentThread();

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -7,6 +7,7 @@ namespace zen::display_system::oculus {
 struct OpenXRContext {
   XrInstance instance{XR_NULL_HANDLE};
   XrSystemId system_id{XR_NULL_SYSTEM_ID};
+  XrSession session{XR_NULL_HANDLE};
   XrViewConfigurationType view_configuration_type{};
   XrEnvironmentBlendMode environment_blend_mode{};
 

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -8,6 +8,7 @@ struct OpenXRContext {
   XrInstance instance{XR_NULL_HANDLE};
   XrSystemId system_id{XR_NULL_SYSTEM_ID};
   XrSession session{XR_NULL_HANDLE};
+  XrSpace app_space{XR_NULL_HANDLE};
   XrViewConfigurationType view_configuration_type{};
   XrEnvironmentBlendMode environment_blend_mode{};
 

--- a/app/src/main/cpp/openxr-program.cc
+++ b/app/src/main/cpp/openxr-program.cc
@@ -26,6 +26,7 @@ namespace {
 // Create other to_string function on demand
 MAKE_TO_STRING_FUNC(XrEnvironmentBlendMode);
 MAKE_TO_STRING_FUNC(XrFormFactor);
+MAKE_TO_STRING_FUNC(XrReferenceSpaceType);
 MAKE_TO_STRING_FUNC(XrResult);
 MAKE_TO_STRING_FUNC(XrViewConfigurationType);
 
@@ -89,6 +90,8 @@ OpenXRProgram::InitializeContext(const std::unique_ptr<OpenXRContext> &context,
   if (!InitializeGraphicsLibrary(context)) return false;
 
   if (!InitializeSession(context)) return false;
+
+  LogReferenceSpaces(context);
 
   return true;
 }
@@ -363,6 +366,33 @@ OpenXRProgram::InitializeEnvironmentBlendMode(
   }
 
   return true;
+}
+
+void
+OpenXRProgram::LogReferenceSpaces(
+    const std::unique_ptr<OpenXRContext> &context) const
+{
+  CHECK(context->session != XR_NULL_HANDLE);
+
+  uint32_t space_count;
+  IF_XR_FAILED (err,
+      xrEnumerateReferenceSpaces(context->session, 0, &space_count, nullptr)) {
+    LOG_WARN("%s", err.c_str());
+    return;
+  }
+
+  std::vector<XrReferenceSpaceType> spaces(space_count);
+
+  IF_XR_FAILED (err, xrEnumerateReferenceSpaces(context->session, space_count,
+                         &space_count, spaces.data())) {
+    LOG_WARN("%s", err.c_str());
+    return;
+  }
+
+  LOG_DEBUG("Available reference spaces: %d", space_count);
+  for (auto space : spaces) {
+    LOG_DEBUG("    Name: %s", to_string(space));
+  }
 }
 
 void

--- a/app/src/main/cpp/openxr-program.cc
+++ b/app/src/main/cpp/openxr-program.cc
@@ -239,7 +239,7 @@ OpenXRProgram::InitializeSession(
   XrGraphicsBindingOpenGLESAndroidKHR graphics_binding{
       XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR};
   graphics_binding.display = context->egl->display();
-  graphics_binding.config = (EGLConfig)0;
+  graphics_binding.config = context->egl->config();
   graphics_binding.context = context->egl->context();
 
   session_create_info.next =

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -33,6 +33,9 @@ class OpenXRProgram {
   /* Create a new XrSession and store it in the context */
   bool InitializeSession(const std::unique_ptr<OpenXRContext> &context) const;
 
+  /* Create a new app space and store it in the context */
+  bool InitializeAppSpace(const std::unique_ptr<OpenXRContext> &context) const;
+
   /* Write out available view configurations, determine the view config type
    * to use and store it in the context */
   bool InitializeViewConfig(

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -30,6 +30,9 @@ class OpenXRProgram {
   bool InitializeGraphicsLibrary(
       const std::unique_ptr<OpenXRContext> &context) const;
 
+  /* Create a new XrSession and store it in the context */
+  bool InitializeSession(const std::unique_ptr<OpenXRContext> &context) const;
+
   /* Write out available view configurations, determine the view config type
    * to use and store it in the context */
   bool InitializeViewConfig(

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -43,6 +43,9 @@ class OpenXRProgram {
   bool InitializeEnvironmentBlendMode(
       const std::unique_ptr<OpenXRContext> &context) const;
 
+  /* Write out reference spaces */
+  void LogReferenceSpaces(const std::unique_ptr<OpenXRContext> &context) const;
+
   /* Write out XrInstance info */
   void LogInstanceInfo(const std::unique_ptr<OpenXRContext> &context) const;
 

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -7,6 +7,8 @@
 #include <android_native_app_glue.h>
 #include <boost/version.hpp>
 #include <cinttypes>
+#include <glm/gtx/quaternion.hpp>
+#include <glm/vec3.hpp>
 #include <memory>
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>


### PR DESCRIPTION
# [b70947a](https://github.com/zigen-project/zen-oculus-display-system/pull/6/commits/b70947a0b99e7a658152db795c525f60216284ee)

## Context

XrSession
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#session
> A session represents an application’s intention to display XR content to the user.

> During [XrSession](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XrSession) creation the application must provide information about which graphics API it intends to use by adding an XrGraphicsBinding* struct of one (and only one) of the enabled graphics API extensions to the next chain of [XrSessionCreateInfo](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XrSessionCreateInfo). The application must call the xrGet*GraphicsRequirements method (where * is a placeholder) provided by the chosen graphics API extension before attempting to create the session.

I did it in the previous pull request.

## Summary
 - [x] create session.

## How to check behavior

1. Build and run with your Oculus Quest
You will see the following log.

```log
I/OpenXR: ------------ xrCreateSession [start] -----------
... long log ...
I/OpenXR: ------------ xrCreateSession [end] -----------
```

# 66bbfae 626c423

## Context

Spaces
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#spaces
> Across both virtual reality and augmented reality, XR applications have a core need to map the location of virtual objects to the corresponding real-world locations where they will be rendered. Spaces allow applications to explicitly create and specify the frames of reference in which they choose to track the real world, and then determine how those frames of reference move relative to one another over time.

Reference space
> OpenXR defines a set of well-known reference spaces that applications use to bootstrap their spatial reasoning. These reference spaces are: VIEW, LOCAL and STAGE. Each reference space has a well-defined meaning, which establishes where its origin is positioned and how its axes are oriented.

See [spec](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#reference-spaces) for the details of each reference spaces.

## Summary
 - [x] Write our reference spaces info
 - [x] Create app space

## How to check behavior

1. update git submodules for glm (https://glm.g-truc.net/0.9.9/index.html)
2. Build and run with your Oculus Quest
You will see the following log.

```log
D/ZEN: Available reference spaces: 3
D/ZEN:     Name: XR_REFERENCE_SPACE_TYPE_LOCAL
D/ZEN:     Name: XR_REFERENCE_SPACE_TYPE_VIEW
D/ZEN:     Name: XR_REFERENCE_SPACE_TYPE_STAGE
```