### PR TITLE
Initialize views and swapchains

### DIFF
--- a/app/src/main/cpp/logger-android.cc
+++ b/app/src/main/cpp/logger-android.cc
@@ -7,10 +7,8 @@ namespace zen::display_system::oculus {
 namespace {
 
 class AndroidLogger : public ILogger {
-  virtual void Print(Severity severity,
-      [[maybe_unused]] const char* pretty_function,
-      [[maybe_unused]] const char* file, [[maybe_unused]] int line,
-      const char* format, ...) final
+  virtual void Print(Severity severity, const char* /*pretty_function*/,
+      const char* /*file*/, int /*line*/, const char* format, ...) final
   {
     const char tag[] = "ZEN";
     android_LogPriority priority = ANDROID_LOG_INFO;

--- a/app/src/main/cpp/main.cc
+++ b/app/src/main/cpp/main.cc
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "logger.h"
+#include "openxr-action.h"
 #include "openxr-context.h"
 #include "openxr-program.h"
 
@@ -16,20 +17,24 @@ android_main(struct android_app *app)
     InitializeLogger();
     LOG_DEBUG("Boost Version %d", BOOST_VERSION);
 
-    auto openxr_context = std::make_unique<OpenXRContext>();
+    auto context = std::make_unique<OpenXRContext>();
     auto openxr = std::make_unique<OpenXRProgram>();
+    auto action = std::make_unique<OpenXRAction>();
 
     if (!openxr->InitializeLoader(app)) {
       LOG_ERROR("Failed to initialize OpenXR loader");
       return;
     }
 
-    if (!openxr->InitializeContext(openxr_context, app)) {
+    if (!openxr->InitializeContext(context, app)) {
       LOG_ERROR("Failed to initialize OpenXR context");
       return;
     }
 
-    // TODO: Initialize actions
+    if (!openxr->InitializeAction(context, action)) {
+      LOG_ERROR("Failed to initialize OpenXR actions");
+      return;
+    }
 
     app->activity->vm->DetachCurrentThread();
   } catch (const std::exception &e) {

--- a/app/src/main/cpp/main.cc
+++ b/app/src/main/cpp/main.cc
@@ -30,7 +30,6 @@ android_main(struct android_app *app)
     }
 
     // TODO: Initialize actions
-    // TODO: Register Debug Message Callback for OpenGL
 
     app->activity->vm->DetachCurrentThread();
   } catch (const std::exception &e) {

--- a/app/src/main/cpp/openxr-action.h
+++ b/app/src/main/cpp/openxr-action.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace zen::display_system::oculus {
+
+struct OpenXRAction {
+  friend class OpenXRProgram;
+
+ private:
+  XrActionSet action_set{XR_NULL_HANDLE};
+  XrAction quit_action{XR_NULL_HANDLE};
+};
+
+}  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -5,6 +5,8 @@
 namespace zen::display_system::oculus {
 
 struct OpenXRContext {
+  struct Swapchain;
+
   XrInstance instance{XR_NULL_HANDLE};
   XrSystemId system_id{XR_NULL_SYSTEM_ID};
   XrSession session{XR_NULL_HANDLE};
@@ -12,12 +14,26 @@ struct OpenXRContext {
   XrViewConfigurationType view_configuration_type{};
   XrEnvironmentBlendMode environment_blend_mode{};
 
+  /**
+   * The following vectors are of the samve size, and items at the same index
+   * correspond to each other.
+   */
+  std::vector<XrView> views;  // resized properly when initialized
+  std::vector<Swapchain> swapchains;
+
   std::unique_ptr<EglInstance> egl;
 
   static constexpr XrViewConfigurationType kAcceptableViewConfigType =
       XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
   static constexpr XrEnvironmentBlendMode kAcceptableEnvironmentBlendModeType =
       XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+};
+
+struct OpenXRContext::Swapchain {
+  int32_t width;
+  int32_t height;
+  XrSwapchain handle;
+  std::vector<XrSwapchainImageOpenGLESKHR> images;
 };
 
 }  // namespace zen::display_system::oculus

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -5,6 +5,9 @@
 namespace zen::display_system::oculus {
 
 struct OpenXRContext {
+  friend class OpenXRProgram;
+
+ private:
   struct Swapchain;
 
   XrInstance instance{XR_NULL_HANDLE};

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -18,7 +18,7 @@ struct OpenXRContext {
   XrEnvironmentBlendMode environment_blend_mode{};
 
   /**
-   * The following vectors are of the samve size, and items at the same index
+   * The following vectors are of the same size, and items at the same index
    * correspond to each other.
    */
   std::vector<XrView> views;  // resized properly when initialized

--- a/app/src/main/cpp/openxr-program.cc
+++ b/app/src/main/cpp/openxr-program.cc
@@ -121,6 +121,8 @@ OpenXRProgram::InitializeContext(const std::unique_ptr<OpenXRContext> &context,
 
   if (!InitializeAppSpace(context)) return false;
 
+  if (!InitializeViews(context)) return false;
+
   return true;
 }
 
@@ -274,6 +276,167 @@ OpenXRProgram::InitializeAppSpace(
     LOG_ERROR("%s", err.c_str());
     return false;
   }
+
+  return true;
+}
+
+bool
+OpenXRProgram::InitializeViews(
+    const std::unique_ptr<OpenXRContext> &context) const
+{
+  CHECK(context->instance != XR_NULL_HANDLE);
+  CHECK(context->system_id != XR_NULL_SYSTEM_ID);
+  CHECK(context->session != XR_NULL_HANDLE);
+  CHECK(context->egl);
+
+  XrSystemProperties system_properties{XR_TYPE_SYSTEM_PROPERTIES};
+  IF_XR_FAILED (err, xrGetSystemProperties(context->instance,
+                         context->system_id, &system_properties)) {
+    LOG_ERROR("%s", err.c_str());
+    return false;
+  }
+
+  LOG_DEBUG("System Properties: Name=%s VendorId=%d",
+      system_properties.systemName, system_properties.vendorId);
+  LOG_DEBUG("System Graphics Properties: MaxWidth=%d MaxHeight=%d MaxLayers=%d",
+      system_properties.graphicsProperties.maxSwapchainImageWidth,
+      system_properties.graphicsProperties.maxSwapchainImageHeight,
+      system_properties.graphicsProperties.maxLayerCount);
+  LOG_DEBUG(
+      "System Tracking Properties: OrientationTracking=%s PositionTracking=%s",
+      system_properties.trackingProperties.orientationTracking == XR_TRUE
+          ? "True"
+          : "False",
+      system_properties.trackingProperties.positionTracking == XR_TRUE
+          ? "True"
+          : "False");
+
+  // Get View Configuration Views
+  uint32_t view_count;
+  std::vector<XrViewConfigurationView> config_views;
+  {
+    IF_XR_FAILED (err,
+        xrEnumerateViewConfigurationViews(context->instance, context->system_id,
+            context->view_configuration_type, 0, &view_count, nullptr)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    if (view_count == 0) {
+      LOG_ERROR("Failed to find an available view");
+      return false;
+    }
+
+    config_views.resize(view_count);
+
+    IF_XR_FAILED (err, xrEnumerateViewConfigurationViews(context->instance,
+                           context->system_id, context->view_configuration_type,
+                           view_count, &view_count, config_views.data())) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+  }
+
+  // Select Swapchain Format
+  int64_t color_swapchain_format = 0;
+  {
+    uint32_t swapchain_format_count;
+    const std::vector<int64_t> kSupportedColorSwapchainFormats{
+        GL_RGBA8, GL_RGBA8_SNORM, GL_SRGB8_ALPHA8};
+
+    IF_XR_FAILED (err, xrEnumerateSwapchainFormats(context->session, 0,
+                           &swapchain_format_count, nullptr)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    std::vector<int64_t> swapchain_formats(swapchain_format_count);
+
+    IF_XR_FAILED (err,
+        xrEnumerateSwapchainFormats(context->session, swapchain_format_count,
+            &swapchain_format_count, swapchain_formats.data())) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    auto swapchain_format_iterator =
+        std::find_first_of(swapchain_formats.begin(), swapchain_formats.end(),
+            kSupportedColorSwapchainFormats.begin(),
+            kSupportedColorSwapchainFormats.end());
+
+    if (swapchain_format_iterator == swapchain_formats.end()) {
+      LOG_ERROR("No runtime swapchain format supported for color swapchain");
+      return false;
+    }
+
+    color_swapchain_format = *swapchain_format_iterator;
+
+    std::stringstream formats_string_stream;
+    for (auto format : swapchain_formats) {
+      const bool selected = format == color_swapchain_format;
+
+      formats_string_stream << " ";
+      if (selected) formats_string_stream << "[";
+      formats_string_stream << "0x" << std::hex << format;
+      if (selected) formats_string_stream << "]";
+    }
+
+    LOG_DEBUG("Swapchain Formats: %s", formats_string_stream.str().c_str());
+  }
+
+  // Create a swapchain for each view
+  for (uint32_t i = 0; i < view_count; i++) {
+    auto &config_view = config_views[i];
+    LOG_DEBUG(
+        "Creating swapchain for view %d with dimensions Width=%d Height=%d "
+        "SampleCount=%d",
+        i, config_view.recommendedImageRectWidth,
+        config_view.recommendedImageRectHeight,
+        config_view.recommendedSwapchainSampleCount);
+
+    XrSwapchainCreateInfo swapchain_create_info{XR_TYPE_SWAPCHAIN_CREATE_INFO};
+    swapchain_create_info.arraySize = 1;
+    swapchain_create_info.format = color_swapchain_format;
+    swapchain_create_info.width = config_view.recommendedImageRectWidth;
+    swapchain_create_info.height = config_view.recommendedImageRectHeight;
+    swapchain_create_info.mipCount = 1;
+    swapchain_create_info.faceCount = 1;
+    swapchain_create_info.sampleCount =
+        config_view.recommendedSwapchainSampleCount;
+    swapchain_create_info.usageFlags = XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
+
+    OpenXRContext::Swapchain swapchain;
+    swapchain.width = config_view.recommendedImageRectWidth;
+    swapchain.height = config_view.recommendedImageRectHeight;
+    IF_XR_FAILED (err, xrCreateSwapchain(context->session,
+                           &swapchain_create_info, &swapchain.handle)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    uint32_t image_count;
+    IF_XR_FAILED (err, xrEnumerateSwapchainImages(
+                           swapchain.handle, 0, &image_count, nullptr)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    swapchain.images.resize(
+        image_count, {XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_ES_KHR});
+
+    IF_XR_FAILED (err,
+        xrEnumerateSwapchainImages(swapchain.handle, image_count, &image_count,
+            reinterpret_cast<XrSwapchainImageBaseHeader *>(
+                swapchain.images.data()))) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    context->swapchains.push_back(swapchain);
+  }
+
+  // Resize view buffer for xrLocateViews later.
+  context->views.resize(view_count, {XR_TYPE_VIEW});
 
   return true;
 }

--- a/app/src/main/cpp/openxr-program.cc
+++ b/app/src/main/cpp/openxr-program.cc
@@ -127,6 +127,98 @@ OpenXRProgram::InitializeContext(const std::unique_ptr<OpenXRContext> &context,
 }
 
 bool
+OpenXRProgram::InitializeAction(const std::unique_ptr<OpenXRContext> &context,
+    const std::unique_ptr<OpenXRAction> &action) const
+{
+  // Create an action set
+  {
+    XrActionSetCreateInfo action_set_create_info{
+        XR_TYPE_ACTION_SET_CREATE_INFO};
+    strcpy(action_set_create_info.actionSetName, "zen");
+    strcpy(action_set_create_info.localizedActionSetName, "zen");
+    action_set_create_info.priority = 0;
+    IF_XR_FAILED (err, xrCreateActionSet(context->instance,
+                           &action_set_create_info, &action->action_set)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+  }
+
+  // Create actions
+  {
+    XrActionCreateInfo action_create_info{XR_TYPE_ACTION_CREATE_INFO};
+    action_create_info.actionType = XR_ACTION_TYPE_BOOLEAN_INPUT;
+    strcpy(action_create_info.actionName, "quit_session");
+    strcpy(action_create_info.localizedActionName, "Quit Session");
+    action_create_info.countSubactionPaths = 0;
+    action_create_info.subactionPaths = nullptr;
+    IF_XR_FAILED (err, xrCreateAction(action->action_set, &action_create_info,
+                           &action->quit_action)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+  }
+
+  // Bind actions
+  {
+    std::array<XrPath, 2> menu_click_path;  // 0: right, 1: left
+    XrPath khr_simple_interaction_profile_path;
+    IF_XR_FAILED (err,
+        xrStringToPath(context->instance, "/user/hand/right/input/menu/click",
+            &menu_click_path[0])) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    IF_XR_FAILED (err,
+        xrStringToPath(context->instance, "/user/hand/left/input/menu/click",
+            &menu_click_path[1])) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    IF_XR_FAILED (err, xrStringToPath(context->instance,
+                           "/interaction_profiles/khr/simple_controller",
+                           &khr_simple_interaction_profile_path)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+
+    std::vector<XrActionSuggestedBinding> bindings{{
+        {action->quit_action, menu_click_path[0]},
+        {action->quit_action, menu_click_path[1]},
+    }};
+
+    XrInteractionProfileSuggestedBinding suggested_bindings{
+        XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING};
+    suggested_bindings.interactionProfile = khr_simple_interaction_profile_path;
+    suggested_bindings.suggestedBindings = bindings.data();
+    suggested_bindings.countSuggestedBindings = bindings.size();
+
+    IF_XR_FAILED (err, xrSuggestInteractionProfileBindings(
+                           context->instance, &suggested_bindings)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+  }
+
+  // Attach the action set to the session
+  {
+    XrSessionActionSetsAttachInfo attach_info{
+        XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO};
+    attach_info.countActionSets = 1;
+    attach_info.actionSets = &action->action_set;
+    IF_XR_FAILED (err,
+        xrAttachSessionActionSets(context->session, &attach_info)) {
+      LOG_ERROR("%s", err.c_str());
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool
 OpenXRProgram::InitializeInstance(const std::unique_ptr<OpenXRContext> &context,
     struct android_app *app) const
 {

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common.h"
+#include "openxr-action.h"
 #include "openxr-context.h"
 
 namespace zen::display_system::oculus {
@@ -17,6 +18,10 @@ class OpenXRProgram {
   /* Initialize OpenXRContext */
   bool InitializeContext(const std::unique_ptr<OpenXRContext> &context,
       struct android_app *app) const;
+
+  /* Initialize OpenXRAction */
+  bool InitializeAction(const std::unique_ptr<OpenXRContext> &context,
+      const std::unique_ptr<OpenXRAction> &action) const;
 
  private:
   /* Create a new XrInstance and store it in the context */

--- a/app/src/main/cpp/openxr-program.h
+++ b/app/src/main/cpp/openxr-program.h
@@ -36,6 +36,9 @@ class OpenXRProgram {
   /* Create a new app space and store it in the context */
   bool InitializeAppSpace(const std::unique_ptr<OpenXRContext> &context) const;
 
+  /* Allocate view buffer and create a swapchain for each view */
+  bool InitializeViews(const std::unique_ptr<OpenXRContext> &context) const;
+
   /* Write out available view configurations, determine the view config type
    * to use and store it in the context */
   bool InitializeViewConfig(

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -5,6 +5,7 @@
 #include <GLES3/gl32.h>
 #include <android/log.h>
 #include <android_native_app_glue.h>
+#include <array>
 #include <boost/version.hpp>
 #include <cinttypes>
 #include <glm/gtx/quaternion.hpp>


### PR DESCRIPTION
# [02b8c7d](https://github.com/zigen-project/zen-oculus-display-system/pull/7/commits/02b8c7d2111cc5f43918b95b76ace0889149061c)

## Context

Views
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#view-projections
> An application uses [xrLocateViews](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#xrLocateViews) to retrieve the viewer pose and projection parameters needed to render each view for use in a composition projection layer.
```c
typedef struct XrView {
    XrStructureType    type;
    void*              next;
    XrPosef            pose;
    XrFovf             fov;
} XrView;
```

Swapchain
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#swapchain-image-management

Wikipedia
> In [computer graphics](https://en.wikipedia.org/wiki/Computer_graphics_(computer_science)), a swap chain (also swapchain) is a series of virtual [framebuffers](https://en.wikipedia.org/wiki/Framebuffer) used by the [graphics card](https://en.wikipedia.org/wiki/Graphics_card) and graphics [API](https://en.wikipedia.org/wiki/API) for [frame rate](https://en.wikipedia.org/wiki/Frame_rate) stabilization, stutter reduction, and several other purposes. Because of these benefits, many graphics APIs require the use of a swap chain. The swap chain usually exists in [graphics memory](https://en.wikipedia.org/wiki/Video_card#Video_memory), but it can exist in system memory as well. A swap chain with two buffers is a [double buffer](https://en.wikipedia.org/wiki/Double_buffer).


## Summary

- [x] Detect view count and allocate a buffer for the views
- [x] Setup swapchain for each view.

## How to check behavior

1. build and run with your Oculus Quest
you will see the following log creating views of both eyes.
```log
D/ZEN: Creating swapchain for view 0 with dimensions Width=1440 Height=1584 SampleCount=1
... logs of internal components ...
D/ZEN: Creating swapchain for view 1 with dimensions Width=1440 Height=1584 SampleCount=1
```

# [4644875](https://github.com/zigen-project/zen-oculus-display-system/pull/7/commits/4644875df44899eb4822b26fb7afd739f6dd8b68)

## Context

We should write out OpenGL debug log

## Summary

- [x] Add OpenGL log handle callback

## How to check behavior

Nothing to do now.

# [af2ac8b](https://github.com/zigen-project/zen-oculus-display-system/pull/7/commits/af2ac8bbcf667d756bef91cef8c3b1c658c66afc)

## Context

Actions
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#_action_overview
> OpenXR applications communicate with input devices using XrActions. Actions are created at initialization time and later used to request input device state, create action spaces, or control haptic events. Input action handles represent 'actions' that the application is interested in obtaining the state of, not direct input device hardware. For example, instead of the application directly querying the state of the A button when interacting with a menu, an OpenXR application instead creates a menu_select action at startup then asks OpenXR for the state of the action.

Action set
spec: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#input-action-creation
> Action sets are application-defined collections of actions. They are attached to a given [XrSession](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XrSession) with a [xrAttachSessionActionSets](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#xrAttachSessionActionSets) call. They are enabled or disabled by the application via [xrSyncActions](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#xrSyncActions) depending on the current application context. For example, a game may have one set of actions that apply to controlling a character and another set for navigating a menu system. When these actions are grouped into two [XrActionSet](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XrActionSet) handles they can be selectively enabled and disabled using a single function call.

## Summary

- [x] Initialize action set and "quit" action.

## How to check behavior

1. build and run with your Oculus Quest
you will see the following log.
```log
I/OpenXR_Actions: ------------ xrCreateActionSet ---------
I/OpenXR_Actions: ------------ xrCreateAction ------------
I/OpenXR_Actions: -- xrSuggestInteractionProfileBindings -
I/OpenXR_Actions: ----- xrAttachSessionActionSets --------
```