### PR TITLE
use git submodules for remote display system

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "app/3rdParty/zen-remote-display-system"]
+	path = app/3rdParty/zen-remote-display-system
+	url = https://github.com/zigen-project/zen-remote-display-system.git

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -17,14 +17,13 @@ FetchContent_Declare(
   GIT_REPOSITORY "https://github.com/g-truc/glm.git"
   GIT_TAG 0.9.9.8
 )
+FetchContent_MakeAvailable(glm_content)
 
 set(REQUIRED_ZEN_REMOTE_DISPLAY_SYSTEM_VERSION 0.1.0.2)
-FetchContent_Declare(
-  remote_display_system_content
-  GIT_REPOSITORY "https://github.com/zigen-project/zen-remote-display-system.git"
-  GIT_TAG main
+add_subdirectory(
+  ${PROJECT_DIR}/3rdParty/zen-remote-display-system
+  zen-remote-display-system
 )
-FetchContent_MakeAvailable(glm_content remote_display_system_content)
 
 # Don't call FetchContent_MakeAvailable so that add_subdirectories is not called
 FetchContent_Declare(


### PR DESCRIPTION
## Context

We used CMake's Fetch_Content to fetch [zen-remote-display-system](https://github.com/zigen-project/zen-remote-display-system). But it was hard to develop [zen-remote-display-system](https://github.com/zigen-project/zen-remote-display-system) and this repository at the same time. Using git submodules seems better in this situation.
We still use CMake FetchContent for other 3rdParty libraries, glm, OpenXR and Boost.

## Summary

- [x] use git submodules for [zen-remote-display-system](https://github.com/zigen-project/zen-remote-display-system)

## How to check behavior

1. Check that nothing about behavior have changed
