### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint-build:
@@ -20,6 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: main
+          submodules: true
 
       - name: ClangFormat Check
         run: find . -regex "^\.\/app/src/main/cpp/.*\.\(h\|cpp\)" | xargs clang-format-14 --dry-run -Werror


### PR DESCRIPTION
## Context

Now CI is failing.

## Summary

- [x] Fix CI
- [x] Run CI on submitting pull request. Previously, we avoid to do so because building Boost is too costy. But now we are using prebuild Boost headers, and we can make it.

## How to check behavior

Check that CI succeed.