### PR TITLE
update zen-remote v0.1.0.6

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(glm_content)
 
-set(ZEN_REMOTE_REQUIRED_VERSION 0.1.0.5)
+set(ZEN_REMOTE_REQUIRED_VERSION 0.1.0.6)
 add_subdirectory(
   ${PROJECT_DIR}/3rdParty/zen-remote
   zen-remote

--- a/app/src/main/cpp/main.cc
+++ b/app/src/main/cpp/main.cc
@@ -45,10 +45,10 @@ android_main(struct android_app *app)
       return;
     }
 
-    std::unique_ptr<zen::remote::IRemote> remote;
+    std::unique_ptr<zen::remote::client::IRemote> remote;
     {
       auto remote_loop = std::make_unique<RemoteLoop>(loop);
-      remote = zen::remote::CreateRemote(std::move(remote_loop));
+      remote = zen::remote::client::CreateRemote(std::move(remote_loop));
     }
 
     remote->Start();

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -17,6 +17,6 @@
 #include <stdarg.h>
 #include <string>
 #include <vector>
+#include <zen-remote/client/remote.h>
 #include <zen-remote/logger.h>
 #include <zen-remote/loop.h>
-#include <zen-remote/remote.h>


### PR DESCRIPTION
## Context

https://github.com/zigen-project/zen-remote/pull/10

## Summary

- [x] update zen-remote to v0.1.0.6

## How to check behavior

see https://github.com/zigen-project/zen-remote/pull/10

## Note

I will update zen-remote submodule after https://github.com/zigen-project/zen-remote/pull/10 is merged.
CI must fail until then