### PR TITLE
fix zen-remote configuration

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -24,6 +24,7 @@ FetchContent_MakeAvailable(glm_content)
 set(ZEN_REMOTE_REQUIRED_VERSION 0.1.0.9)
 set(ZEN_REMOTE_SERVER OFF)
 set(ZEN_REMOTE_CLIENT ON)
+set(ZEN_REMOTE_GRAPHICS_API GLESv3)
 add_subdirectory(
   ${PROJECT_DIR}/3rdParty/zen-remote
   zen-remote


### PR DESCRIPTION
## Context

https://github.com/zigen-project/zen-remote/pull/23 changes default configuration of zen-remote build.

This pull request adapt to it.

## Summary

- [x] Fix zen-remote build configuration

## How to check behavior

Build it.