### PR TITLE
make possible to launch without controller

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         android:name="android.hardware.vr.headtracking"
         android:required="true"
         android:version="1" />
+    <uses-feature
+        android:name="oculus.software.handtracking"
+        android:required="false" />
 
     <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
     <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />


### PR DESCRIPTION
## Context

Now Quest 2 shows warning window when try to launch this client without controller.

## Summary

Add requirement about handtracking (but it isn't required)

## How to check behavior

Build and install, launch by handtracking. You can launch normally.