### PR TITLE
fix app space

### DIFF
--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -22,6 +22,9 @@ class OpenXRContext {
   /* Handle session state update */
   void UpdateSessionState(XrSessionState state, XrTime time);
 
+  /* Create a new app space and store it in the context */
+  bool InitializeAppSpace(XrTime time);
+
   inline XrInstance instance();
   inline XrSystemId system_id();
   inline XrSession session();
@@ -45,9 +48,6 @@ class OpenXRContext {
 
   /* Create a new XrSession and store it in the context */
   bool InitializeSession();
-
-  /* Create a new app space and store it in the context */
-  bool InitializeAppSpace();
 
   /* Write out available view configurations, determine the view config type
    * to use and store it in the context */

--- a/app/src/main/cpp/openxr-view-source.cc
+++ b/app/src/main/cpp/openxr-view-source.cc
@@ -236,6 +236,13 @@ OpenXRViewSource::Process()
     return;
   }
 
+  if (context_->app_space() == XR_NULL_HANDLE) {
+    if (!context_->InitializeAppSpace(frame_state.predictedDisplayTime)) {
+      loop_->Terminate();
+      return;
+    }
+  }
+
   XrFrameBeginInfo frame_begin_info{XR_TYPE_FRAME_BEGIN_INFO};
   IF_XR_FAILED (err, xrBeginFrame(context_->session(), &frame_begin_info)) {
     LOG_ERROR("%s", err.c_str());


### PR DESCRIPTION
## Context

Currently, application space origin is sometime located at unexpected position.

## Summary

Fix app space.

- [x] floor position (view height) is from STAGE reference space
- [x] view x,y, orientation is from the initial HMD pose

## How to check behavior

Start zen oculus remote client at any position and orientation.