### PR TITLE
replace zigen -> zwin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zigen-project/zigen-maintainers
+* @zwin-project/zwin-maintainers

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,29 +18,29 @@ jobs:
       - name: Clone Oculus OpenXR SDK
         uses: actions/checkout@v2
         with:
-          repository: zigen-project/oculus-openxr-mobile-sdk
+          repository: zwin-project/oculus-openxr-mobile-sdk
           path: ovr_openxr_mobile_sdk
-      
+
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install meson
-      
+
       - name: Clone grpc-dev
         uses: actions/checkout@v2
         with:
-          repository: zigen-project/grpc-dev
+          repository: zwin-project/grpc-dev
           path: grpc-dev
           submodules: recursive
-          ref: 'v1.49.1' 
-      
+          ref: "v1.49.1"
+
       - name: Build grpc-dev
         working-directory: ./grpc-dev
         run: |
           echo "ndk_version := $NDK_VERSION" > local.mk
           echo "ndk_dir     := /usr/local/lib/android/sdk/ndk/$NDK_VERSION" >> local.mk
           make android
-      
+
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "app/3rdParty/zen-remote"]
 	path = app/3rdParty/zen-remote
-	url = https://github.com/zigen-project/zen-remote.git
+	url = https://github.com/zwin-project/zen-remote.git

--- a/README.adoc
+++ b/README.adoc
@@ -2,12 +2,12 @@
 
 === Clone
 
-Clone https://github.com/zigen-project/zen-oculus-display-system[this repository]
+Clone https://github.com/zwin-project/zen-oculus-display-system[this repository]
 with its submodules as well.
 
 [source,sh]
 ```
-git clone https://github.com/zigen-project/zen-oculus-display-system.git --recursive
+git clone https://github.com/zwin-project/zen-oculus-display-system.git --recursive
 ```
 
 === Basic environment setup
@@ -24,7 +24,7 @@ This will likely include,
 
 === Build gRPC
 
-Clone and build https://github.com/zigen-project/grpc-dev[grpc-dev],
+Clone and build https://github.com/zwin-project/grpc-dev[grpc-dev],
 using the v1.49.1 branch. We assume that you clone it to `$MY_DIR/grpc-dev`.
 
 NDK version `21.4.7075529` is recommended.
@@ -41,7 +41,7 @@ and set the following items.
 * `ndk.version`: NDK Version (ex 21.4.7075529)
 * `ovr_openxr_mobile_sdk.dir`: Path to the Oculus OpenXR Mobile SDK directory
 * The following three values are used to build zen-remote.
-Please refer to the https://github.com/zigen-project/zen-remote[zen-remote] for details.
+Please refer to the https://github.com/zwin-project/zen-remote[zen-remote] for details.
 ** `protoc`: Path to `$MY_DIR/grpc-dev/native/Debug/bin/protoc`
 ** `grpc_cpp_plugin`: Path to `$MY_DIR/grpc-dev/native/Debug/bin/grpc_cpp_plugin`
 ** `grpc_sysroot`: Path to `$MY_DRI/grpc-dev/android/24/arm64-v8a/21.4.7075529/Debug` +

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
     ndkVersion getRequiredProperty("ndk.version")
 
     defaultConfig {
-        applicationId "io.zigen.zen.mirror"
+        applicationId "io.zwin.zen.mirror"
         minSdk 24
         targetSdk 29
         versionCode 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="io.zigen.zen.oculus_display_system"
+    package="io.zwin.zen.oculus_display_system"
     android:installLocation="auto"
     android:versionCode="1"
     android:versionName="0.1.0">


### PR DESCRIPTION
## Context

To coincide with a organization name change, replace `zigen` -> `zwin`.

## How to check behavior

Build, install, and run.
