### PR TITLE
rename to Zen Mirror

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-ZEN Oculus remote client
+Zen Mirror

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-== ZEN Oculus display system
+== ZEN Mirror
 
 === Issue
 
@@ -6,12 +6,12 @@ Please report issues related to this repository to https://github.com/zwin-proje
 
 === Clone
 
-Clone https://github.com/zwin-project/zen-oculus-display-system[this repository]
+Clone https://github.com/zwin-project/zen-mirror[this repository]
 with its submodules as well.
 
 [source,sh]
 ```
-git clone https://github.com/zwin-project/zen-oculus-display-system.git --recursive
+git clone https://github.com/zwin-project/zen-mirror.git --recursive
 ```
 
 === Basic environment setup

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="dev.zwin.zen.oculus_display_system"
+    package="dev.zwin.zen.mirror"
     android:installLocation="auto"
     android:versionCode="1"
     android:versionName="0.1.0">
@@ -50,7 +50,7 @@
 
             <meta-data
                 android:name="android.app.lib_name"
-                android:value="zen_oculus_display_system" />
+                android:value="zen_mirror" />
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(zen_oculus_display_system C CXX)
+project(zen_mirror C CXX)
 message(STATUS "Using CMake version: ${CMAKE_VERSION}")
 
 set(CMAKE_CXX_STANDARD 17)
@@ -73,7 +73,7 @@ set_property(
 
 # main target
 add_library(
-  zen_oculus_display_system MODULE
+  zen_mirror MODULE
   
   android-logger.cc
   egl-instance.cc
@@ -87,10 +87,10 @@ add_library(
   remote-loop.cc
   $<TARGET_OBJECTS:android_native_app_glue_object>
 )
-target_precompile_headers(zen_oculus_display_system PRIVATE pch.h)
+target_precompile_headers(zen_mirror PRIVATE pch.h)
 
 target_link_libraries(
-  zen_oculus_display_system
+  zen_mirror
 
   PRIVATE
     glm
@@ -103,7 +103,7 @@ target_link_libraries(
 )
 
 target_include_directories(
-  zen_oculus_display_system
+  zen_mirror
 
   PRIVATE
     ${openxr_sdk_content_SOURCE_DIR}/include
@@ -112,7 +112,7 @@ target_include_directories(
 )
 
 target_compile_options(
-  zen_oculus_display_system
+  zen_mirror
 
   PRIVATE
     -Werror -Wall -Winvalid-pch -Wextra -Wpedantic

--- a/app/src/main/cpp/android-logger.cc
+++ b/app/src/main/cpp/android-logger.cc
@@ -2,7 +2,7 @@
 
 #include "logger.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 namespace {
 
@@ -46,4 +46,4 @@ InitializeLogger()
   ILogger::instance = std::make_unique<AndroidLogger>();
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/config.h.in
+++ b/app/src/main/cpp/config.h.in
@@ -1,7 +1,7 @@
 #pragma once
 
-namespace zen::display_system::oculus::config {
+namespace zen::mirror::config {
 
 constexpr const char* APP_NAME = "${APP_NAME}";
 
-}  // namespace zen::display_system::oculus::config
+}  // namespace zen::mirror::config

--- a/app/src/main/cpp/egl-instance.cc
+++ b/app/src/main/cpp/egl-instance.cc
@@ -3,7 +3,7 @@
 #include "egl-instance.h"
 #include "logger.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 namespace {
 
@@ -171,4 +171,4 @@ EglInstance::Initialize()
   return true;
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/egl-instance.h
+++ b/app/src/main/cpp/egl-instance.h
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class EglInstance {
  public:
@@ -41,4 +41,4 @@ EglInstance::context()
   return context_;
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/logger.h
+++ b/app/src/main/cpp/logger.h
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 struct ILogger {
   // logger singleton set by InitializeLogger;
@@ -36,7 +36,7 @@ struct ILogger {
   }
 };
 
-constexpr char kDefaultLoggerTag[] = "ZEN[Oculus]";
+constexpr char kDefaultLoggerTag[] = "ZEN[Mirror]";
 
 #define LOG_DEBUG(format, ...)                                \
   ILogger::instance->Print(ILogger::DEBUG, kDefaultLoggerTag, \
@@ -60,4 +60,4 @@ constexpr char kDefaultLoggerTag[] = "ZEN[Oculus]";
 
 void InitializeLogger();
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/loop.cc
+++ b/app/src/main/cpp/loop.cc
@@ -3,7 +3,7 @@
 #include "logger.h"
 #include "loop.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 void
 Loop::Run()
@@ -73,4 +73,4 @@ Loop::HandleAndroidPollEvent(int result, void *data)
   return false;
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/loop.h
+++ b/app/src/main/cpp/loop.h
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class Loop {
  public:
@@ -37,4 +37,4 @@ struct Loop::ISource {
   virtual void Process() = 0;
 };
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/main.cc
+++ b/app/src/main/cpp/main.cc
@@ -10,7 +10,7 @@
 #include "remote-log-sink.h"
 #include "remote-loop.h"
 
-using namespace zen::display_system::oculus;
+using namespace zen::mirror;
 
 void
 android_main(struct android_app *app)

--- a/app/src/main/cpp/openxr-action-source.cc
+++ b/app/src/main/cpp/openxr-action-source.cc
@@ -4,7 +4,7 @@
 #include "openxr-action-source.h"
 #include "openxr-util.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 OpenXRActionSource::~OpenXRActionSource()
 {
@@ -208,4 +208,4 @@ OpenXRActionSource::Process()
   }
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-action-source.h
+++ b/app/src/main/cpp/openxr-action-source.h
@@ -3,7 +3,7 @@
 #include "loop.h"
 #include "openxr-context.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class OpenXRActionSource : public Loop::ISource {
  public:
@@ -29,4 +29,4 @@ class OpenXRActionSource : public Loop::ISource {
   std::array<XrPath, (size_t)Hand::kCount> hand_subaction_path_;
 };
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-context.cc
+++ b/app/src/main/cpp/openxr-context.cc
@@ -6,7 +6,7 @@
 #include "openxr-context.h"
 #include "openxr-util.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 OpenXRContext::~OpenXRContext()
 {
@@ -587,4 +587,4 @@ OpenXRContext::LogLayersAndExtensions() const
   }
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-context.h
+++ b/app/src/main/cpp/openxr-context.h
@@ -4,7 +4,7 @@
 #include "egl-instance.h"
 #include "loop.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class OpenXRContext {
  public:
@@ -129,4 +129,4 @@ OpenXRContext::environment_blend_mode()
   return environment_blend_mode_;
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-event-source.cc
+++ b/app/src/main/cpp/openxr-event-source.cc
@@ -5,7 +5,7 @@
 #include "openxr-event-source.h"
 #include "openxr-util.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 void
 OpenXREventSource::Process()
@@ -65,4 +65,4 @@ OpenXREventSource::HandleSessionStateChangedEvent(
   context_->UpdateSessionState(event->state, event->time);
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-event-source.h
+++ b/app/src/main/cpp/openxr-event-source.h
@@ -4,7 +4,7 @@
 #include "loop.h"
 #include "openxr-context.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class OpenXREventSource : public Loop::ISource {
  public:
@@ -29,4 +29,4 @@ class OpenXREventSource : public Loop::ISource {
   std::shared_ptr<Loop> loop_;
 };
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-util.h
+++ b/app/src/main/cpp/openxr-util.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 namespace {
 
@@ -118,4 +118,4 @@ ToProjectionMatrix(XrFovf fov, float near, float far)
 
 }  // namespace
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-view-source.cc
+++ b/app/src/main/cpp/openxr-view-source.cc
@@ -4,7 +4,7 @@
 #include "openxr-util.h"
 #include "openxr-view-source.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 constexpr float kRenderingScale = 2.f;
 
@@ -377,4 +377,4 @@ OpenXRViewSource::RenderViews(XrTime predict_display_time,
   return true;
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/openxr-view-source.h
+++ b/app/src/main/cpp/openxr-view-source.h
@@ -3,7 +3,7 @@
 #include "loop.h"
 #include "openxr-context.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class OpenXRViewSource : public Loop::ISource {
  public:
@@ -58,4 +58,4 @@ struct OpenXRViewSource::SwapchainFramebuffer {
   GLuint depth_buffer = 0;
 };
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/remote-log-sink.cc
+++ b/app/src/main/cpp/remote-log-sink.cc
@@ -2,7 +2,7 @@
 
 #include "remote-log-sink.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 void
 RemoteLogSink::Sink(remote::Severity remote_severity,
@@ -34,4 +34,4 @@ RemoteLogSink::Sink(remote::Severity remote_severity,
       severity, "ZEN[Remote]", pretty_function, file, line, format, vp);
 }
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/remote-log-sink.h
+++ b/app/src/main/cpp/remote-log-sink.h
@@ -2,11 +2,11 @@
 
 #include "logger.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class RemoteLogSink : public remote::ILogSink {
   void Sink(remote::Severity remote_severity, const char* pretty_function,
       const char* file, int line, const char* format, va_list vp) override;
 };
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/remote-loop.cc
+++ b/app/src/main/cpp/remote-loop.cc
@@ -3,7 +3,7 @@
 #include "logger.h"
 #include "remote-loop.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 namespace {
 
@@ -77,4 +77,4 @@ RemoteLoop::Terminate()
   main_loop_->Terminate();
 };
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/app/src/main/cpp/remote-loop.h
+++ b/app/src/main/cpp/remote-loop.h
@@ -2,7 +2,7 @@
 
 #include "loop.h"
 
-namespace zen::display_system::oculus {
+namespace zen::mirror {
 
 class RemoteLoop : public remote::ILoop {
  public:
@@ -18,4 +18,4 @@ class RemoteLoop : public remote::ILoop {
   std::shared_ptr<Loop> main_loop_;
 };
 
-}  // namespace zen::display_system::oculus
+}  // namespace zen::mirror

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,5 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "ZEN Oculus remote client"
+rootProject.name = "Zen Mirror"
 include ':app'


### PR DESCRIPTION
## Context

Rename zen-oculus-display-system to zen-mirror.

ref: https://github.com/zwin-project/zen-release-manager/pull/7

## Summary

Rename zen-oculus-display-system to zen-mirror.

## How to check the behavior

<!--
If you have added a new feature, please write a way for other developers
to easily check the behavior you have changed or added, so that they can
keep up with the changes.
-->

## Note

Will change repository name before merging this.
