### PR TITLE
OpenXR spec require 'type' must be 'XR_TYPE_VIEW_CONFIGURATION_VIEW'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  NDK_VERSION: 25.1.8937393
+  NDK_VERSION: 25.2.9519653
 
 jobs:
   lint-build:

--- a/app/src/main/cpp/openxr-view-source.cc
+++ b/app/src/main/cpp/openxr-view-source.cc
@@ -63,9 +63,7 @@ OpenXRViewSource::Init()
       return false;
     }
 
-    config_views.resize(view_count);
-    std::fill(config_views.begin(), config_views.end(),
-              XrViewConfigurationView{XR_TYPE_VIEW_CONFIGURATION_VIEW});
+    config_views.resize(view_count, {XR_TYPE_VIEW_CONFIGURATION_VIEW});
 
     IF_XR_FAILED (err,
         xrEnumerateViewConfigurationViews(context_->instance(),

--- a/app/src/main/cpp/openxr-view-source.cc
+++ b/app/src/main/cpp/openxr-view-source.cc
@@ -64,6 +64,8 @@ OpenXRViewSource::Init()
     }
 
     config_views.resize(view_count);
+    std::fill(config_views.begin(), config_views.end(),
+              XrViewConfigurationView{XR_TYPE_VIEW_CONFIGURATION_VIEW});
 
     IF_XR_FAILED (err,
         xrEnumerateViewConfigurationViews(context_->instance(),

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -17,6 +17,7 @@
 #include <stdarg.h>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include <zen-remote/client/remote.h>
 #include <zen-remote/logger.h>
 #include <zen-remote/loop.h>

--- a/app/src/main/cpp/pch.h
+++ b/app/src/main/cpp/pch.h
@@ -17,7 +17,6 @@
 #include <stdarg.h>
 #include <string>
 #include <vector>
-#include <algorithm>
 #include <zen-remote/client/remote.h>
 #include <zen-remote/logger.h>
 #include <zen-remote/loop.h>


### PR DESCRIPTION
## Context

<!--
Please provide a link to the relevant issue, if available,
so that reviewers can quickly understand the context.

Example:
See zwin-project/.github#8
-->
The pull request is not related to any opened issues.

<!--
If the issue is not well described, add more information here (justification,
pull request links, etc.).
-->
I've run successfully zen-mirror as Android app on the phone with installed Modano runtime. The one problem was a wrong usage of OpenXR API in the place where I suggest changes by this pull request.

## Summary

<!--
Please describe what you did here. If you have made changes to the appearance,
it would be helpful to include images as well.
-->

By the OpenXR API specification, as described in section '8.2.5. XrViewConfigurationView' by a valid usage example, the value of the 'type' field must be 'XR_TYPE_VIEW_CONFIGURATION_VIEW'.

Otherwise the call of the function 'xrEnumerateViewConfigurationViews' returns 'XR_ERROR_VALIDATION_FAILURE'.

## How to check the behavior

<!--
If you have added a new feature, please write a way for other developers
to easily check the behavior you have changed or added, so that they can
keep up with the changes.
-->
I don't know why the structure without set 'type' field doesn't result to crash in the case of run code with Oculus Quest. Looks like it should fails too.
